### PR TITLE
Require Nette 3 packages and supported versions of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2",
-		"nette/database": ">=2.4",
-		"nette/di": ">=2.4",
-		"nette/utils": ">=2.4"
+		"php": "^7.3 || ^8.0",
+		"nette/database": "^3.1",
+		"nette/di": "^3.0",
+		"nette/utils": "^3.2"
 	},
 	"autoload": {
 		"classmap": ["src/"]


### PR DESCRIPTION
We'll switch to requiring `Explorer` instead of now deprecated `Context` soon. The rename was done in Nette Database 3.1.