### PR TITLE
Support nette/utils 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"php": "^8.1",
 		"nette/database": "^3.1",
 		"nette/di": "^3.0",
-		"nette/utils": "^3.2"
+		"nette/utils": "^3.2|^4.0"
 	},
 	"require-dev": {
 		"nette/schema": "^1.2",


### PR DESCRIPTION
The only thing used from the package is `SmartObject` and that hasn't changed, at least not significantly, in 4.0.