### PR TITLE
Support PHP 8.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,6 +12,7 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
~~Waiting behind nette/database to support PHP 8.3~~ added in [3.1.8](https://github.com/nette/database/releases/tag/v3.1.8), but hit another issue https://github.com/nette/database/issues/302