### PR TITLE
Require PHP 8.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.1",
+		"php": "^8.2",
 		"nette/database": "^3.1",
 		"nette/di": "^3.0",
 		"nette/utils": "^3.2|^4.0"


### PR DESCRIPTION
Because of the upcoming [spaze/encryption 2.0](https://github.com/spaze/encryption/releases/tag/v2.0.0) dependency which also requires 8.2.